### PR TITLE
Exclude priv directory from Hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,8 @@ defmodule CSV.Mixfile do
     [
       maintainers: ["Beat Richartz"],
       licenses: ["MIT"],
-      links: %{GitHub: @source_url}
+      links: %{GitHub: @source_url},
+      files: ~w(lib .formatter.exs mix.exs README.md LICENSE CHANGELOG.md src),
     ]
   end
 


### PR DESCRIPTION
The current `hex` package includes a `priv` directory with only PLTs needed for `dialyzer`.

I noticed this while I was inspecting the diff between 3.0.3 and 3.0.4 via: https://diff.hex.pm/diff/csv/3.0.3..3.0.4